### PR TITLE
Solve backwards `Clock` tick

### DIFF
--- a/reminder/src/main/java/com/jeanbarrossilva/h2o/reminder/clock/DefaultClock.kt
+++ b/reminder/src/main/java/com/jeanbarrossilva/h2o/reminder/clock/DefaultClock.kt
@@ -1,6 +1,6 @@
 package com.jeanbarrossilva.h2o.reminder.clock
 
-import com.jeanbarrossilva.h2o.reminder.extensions.localtime.dec
+import com.jeanbarrossilva.h2o.reminder.extensions.localtime.inc
 import kotlinx.coroutines.MainScope
 import java.time.LocalTime
 
@@ -14,6 +14,6 @@ class DefaultClock: Clock() {
     }
 
     override fun onTick() {
-        --currentTime
+        currentTime++
     }
 }

--- a/reminder/src/main/java/com/jeanbarrossilva/h2o/reminder/extensions/localtime/LocalTime.kt
+++ b/reminder/src/main/java/com/jeanbarrossilva/h2o/reminder/extensions/localtime/LocalTime.kt
@@ -8,8 +8,8 @@ import kotlin.time.Duration.Companion.seconds
 internal val LocalTime?.orMin: LocalTime
     get() = this ?: LocalTime.of(0, 0)
 
-internal operator fun LocalTime.dec(): LocalTime {
-    return minusMinutes(1)
+internal operator fun LocalTime.inc(): LocalTime {
+    return plusMinutes(1)
 }
 
 internal operator fun LocalTime.minus(other: LocalTime): Duration {

--- a/reminder/src/test/java/com/jeanbarrossilva/h2o/reminder/ClockTests.kt
+++ b/reminder/src/test/java/com/jeanbarrossilva/h2o/reminder/ClockTests.kt
@@ -2,10 +2,12 @@ package com.jeanbarrossilva.h2o.reminder
 
 import com.jeanbarrossilva.h2o.reminder.fake.FakeClock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import java.time.LocalTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ClockTests {
@@ -15,6 +17,18 @@ class ClockTests {
             val clock = FakeClock(this)
             clock.jumpTo(LocalTime.of(9, 41))
             assertEquals(LocalTime.of(9, 41), clock.getCurrentTime())
+        }
+    }
+
+    @Test
+    fun `GIVEN a clock WHEN ticking THEN it ticks forwards`() {
+        runTest {
+            val clock = FakeClock(this)
+            clock.jumpTo(LocalTime.of(8, 0))
+            clock.start()
+            advanceTimeBy(1.hours.inWholeMilliseconds)
+            clock.stop()
+            assertEquals(LocalTime.of(9, 0), clock.getCurrentTime())
         }
     }
 }

--- a/reminder/src/test/java/com/jeanbarrossilva/h2o/reminder/fake/FakeClock.kt
+++ b/reminder/src/test/java/com/jeanbarrossilva/h2o/reminder/fake/FakeClock.kt
@@ -1,7 +1,7 @@
 package com.jeanbarrossilva.h2o.reminder.fake
 
 import com.jeanbarrossilva.h2o.reminder.clock.Clock
-import com.jeanbarrossilva.h2o.reminder.extensions.localtime.dec
+import com.jeanbarrossilva.h2o.reminder.extensions.localtime.inc
 import com.jeanbarrossilva.h2o.reminder.extensions.localtime.minus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -17,7 +17,7 @@ class FakeClock(override val coroutineScope: TestScope): Clock() {
     }
 
     override fun onTick() {
-        --currentTime
+        currentTime++
     }
 
     fun jumpTo(time: LocalTime) {


### PR DESCRIPTION
Both fake and default `Clock`s were decreasing the current time instead of increasing it.